### PR TITLE
Add CI workflow configuration and refactor .NET CI to use workflow_call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - src/**
       - test/**
       - .github/workflows/ci.yml
+      - .github/workflows/dotnet.yml
       - .config/dotnet-tools.json
       - global.json
       - "*.slnx"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ on:
     paths:
       - src/**
       - test/**
+      - .github/workflows/ci.yml
       - .github/workflows/dotnet.yml
       - .config/dotnet-tools.json
       - global.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - src/**
       - test/**
-      - .github/workflows/dotnet.yml
+      - .github/workflows/ci.yml
       - .config/dotnet-tools.json
       - global.json
       - "*.slnx"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "dev"]
+    paths:
+      - src/**
+      - test/**
+      - .github/workflows/dotnet.yml
+      - .config/dotnet-tools.json
+      - global.json
+      - "*.slnx"
+      - Directory.*.props
+      - Directory.*.targets
+      - coverage.config
+  pull_request:
+    branches: ["main"]
+    paths:
+      - src/**
+      - test/**
+      - .github/workflows/dotnet.yml
+      - .config/dotnet-tools.json
+      - global.json
+      - "*.slnx"
+      - Directory.*.props
+      - Directory.*.targets
+      - coverage.config
+  workflow_dispatch:
+
+jobs:
+  dotnet-build-test:
+    uses: ./.github/workflows/dotnet.yml
+    with:
+      Solution: ""
+    secrets: inherit

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,34 +1,13 @@
 name: .NET CI
 
 on:
-  push:
-    branches: ["main", "dev"]
-    paths:
-      - src/**
-      - test/**
-      - .github/workflows/dotnet.yml
-      - .config/dotnet-tools.json
-      - global.json
-      - "*.slnx"
-      - Directory.*.props
-      - Directory.*.targets
-      - coverage.config
-  pull_request:
-    branches: ["main"]
-    paths:
-      - src/**
-      - test/**
-      - .github/workflows/dotnet.yml
-      - .config/dotnet-tools.json
-      - global.json
-      - "*.slnx"
-      - Directory.*.props
-      - Directory.*.targets
-      - coverage.config
-  workflow_dispatch:
-
-env:
-  SOLUTION: ""
+  workflow_call:
+    inputs:
+      Solution:
+        type: string
+        required: false
+        description: The solution file to build and test
+        default: ""
 
 jobs:
   build:
@@ -48,15 +27,15 @@ jobs:
       - name: Restore .NET tools
         run: dotnet tool restore
       - name: Restore
-        run: dotnet restore ${{ env.SOLUTION }}
+        run: dotnet restore ${{ inputs.Solution }}
       - name: Build
-        run: dotnet build ${{ env.SOLUTION }} --no-restore --configuration Release
+        run: dotnet build ${{ inputs.Solution }} --no-restore --configuration Release
       - name: Verify Format
-        run: dotnet format ${{ env.SOLUTION }} --no-restore --verify-no-changes -v diag --severity info
+        run: dotnet format ${{ inputs.Solution }} --no-restore --verify-no-changes -v diag --severity info
       - name: Test
         shell: pwsh
         run: |
-          dotnet test ${{ env.SOLUTION }} --no-build --configuration Release --verbosity normal -- --coverage --coverage-settings $pwd/coverage.config --coverage-output-format xml --report-xunit
+          dotnet test ${{ inputs.Solution }} --no-build --configuration Release --verbosity normal -- --coverage --coverage-settings $pwd/coverage.config --coverage-output-format xml --report-xunit
           dotnet coverage merge **/TestResults/**.xml --output coverage.xml --output-format xml
       - name: Upload TestResults Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates the continuous integration (CI) workflow configuration to improve modularity and reuse between workflow files. The main change is refactoring the `.github/workflows/dotnet.yml` workflow to be callable from other workflows, and introducing a new top-level CI workflow that delegates to it. This makes the CI setup more maintainable and easier to extend.

**Workflow refactoring and modularization:**

* Added a new `.github/workflows/ci.yml` workflow that triggers on pushes, pull requests, and manual dispatch, and delegates the build and test jobs to the reusable `.github/workflows/dotnet.yml` workflow.
* Refactored `.github/workflows/dotnet.yml` to use the `workflow_call` trigger, allowing it to be called from other workflows and accept the `Solution` input parameter.

**Parameter handling improvements:**

* Updated all job steps in `.github/workflows/dotnet.yml` to use the new `inputs.Solution` parameter instead of the previous environment variable, ensuring the correct solution file is used throughout the workflow.